### PR TITLE
Resize, redraw, and disabling features

### DIFF
--- a/UI-Cropping-Image-Library/CroppingImageLibrary.SampleApp/CroppingWindow.xaml
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary.SampleApp/CroppingWindow.xaml
@@ -2,9 +2,11 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:croppingImageLibrary="clr-namespace:CroppingImageLibrary;assembly=CroppingImageLibrary"
         mc:Ignorable="d"
-        Title="CroppingWindow" ResizeMode="NoResize" WindowStartupLocation="Manual" SizeToContent ="WidthAndHeight">
-    <croppingImageLibrary:CropToolControl Name="CropTool"></croppingImageLibrary:CropToolControl>
+        Title="CroppingWindow" WindowStartupLocation="Manual" SizeToContent ="WidthAndHeight"
+        d:DesignHeight="450" d:DesignWidth="800"
+        >
+    <croppingImageLibrary:CropToolControl Name="CropTool"/>
 </Window>

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml
@@ -9,7 +9,7 @@
         <Border Background="LightBlue">
             <Image x:Name="SourceImage"
                    Stretch="Uniform" 
-                   SizeChanged="RootGrid_SizeChanged"
+                   SizeChanged="SourceImage_SizeChanged"
                    />
         </Border>
     </Grid>

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml
@@ -8,7 +8,9 @@
     <Grid x:Name="RootGrid" MouseLeftButtonDown="RootGrid_OnMouseLeftButtonDown" MouseLeftButtonUp="RootGrid_MouseLeftButtonUp" Loaded="RootGrid_Loaded">
         <Border Background="LightBlue">
             <Image x:Name="SourceImage"
-                   Stretch="None" />
+                   Stretch="Uniform" 
+                   SizeChanged="RootGrid_SizeChanged"
+                   />
         </Border>
     </Grid>
 </UserControl>

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml.cs
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml.cs
@@ -31,14 +31,17 @@ namespace CroppingImageLibrary
 
         private void RootGrid_Loaded(object sender, RoutedEventArgs e)
         {
-            CropService = new CropService(this);
+            CropService = new CropService(SourceImage);
         }
 
         public void SetImage(BitmapImage bitmapImage)
         {
             SourceImage.Source = bitmapImage;
-            RootGrid.Height = bitmapImage.Height;
-            RootGrid.Width = bitmapImage.Width;
+        }
+
+        private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            CropService?.SizeChanged(sender, e);
         }
     }
 }

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml.cs
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/CropToolControl.xaml.cs
@@ -39,7 +39,7 @@ namespace CroppingImageLibrary
             SourceImage.Source = bitmapImage;
         }
 
-        private void RootGrid_SizeChanged(object sender, SizeChangedEventArgs e)
+        private void SourceImage_SizeChanged(object sender, SizeChangedEventArgs e)
         {
             CropService?.SizeChanged(sender, e);
         }

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/Services/CropService.cs
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/Services/CropService.cs
@@ -32,8 +32,11 @@ namespace CroppingImageLibrary.Services
         private readonly IToolState _createState;
         private readonly IToolState _dragState;
         private readonly IToolState _completeState;
+        private readonly FrameworkElement _adornedElement;
 
         public Adorner Adorner => _cropAdorner;
+
+        public bool IsEnabled { get; private set; }
 
         private enum TouchPoint
         {
@@ -78,6 +81,7 @@ namespace CroppingImageLibrary.Services
             _cropAdorner.MouseLeftButtonUp += AdornerOnMouseLeftButtonUp;
 
             _cropTool.Redraw(0, 0, 0, 0);
+            this._adornedElement = adornedElement;
         }
 
         public CropArea GetCroppedArea() =>
@@ -100,7 +104,6 @@ namespace CroppingImageLibrary.Services
             {
                 _cropTool.Redraw(newPosition.Value.Left, newPosition.Value.Top, newPosition.Value.Width, newPosition.Value.Height);
             }
-
         }
 
         private void AdornerOnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -119,6 +122,23 @@ namespace CroppingImageLibrary.Services
             _currentToolState.OnMouseDown(point);
         }
 
+        public void SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            Redraw(_adornedElement.ActualWidth,
+                                _adornedElement.ActualHeight,
+                                e.NewSize.Width / e.PreviousSize.Width,
+                                e.NewSize.Height / e.PreviousSize.Height);
+        }
+
+        public void SetEnabled(bool isEnabled)
+        {
+            IsEnabled = isEnabled;
+            _canvas.Visibility = isEnabled ? Visibility.Visible : Visibility.Hidden;
+            _canvas.IsEnabled = isEnabled;
+            _cropAdorner.Visibility = isEnabled ? Visibility.Visible : Visibility.Hidden;
+            _cropAdorner.IsEnabled = isEnabled;
+        }
+
         private TouchPoint GetTouchPoint(Point mousePoint)
         {
             //left
@@ -135,6 +155,27 @@ namespace CroppingImageLibrary.Services
                 return TouchPoint.OutsideRectangle;
 
             return TouchPoint.InsideRectangle;
+        }
+
+        public void Redraw(double canvasWidth, double canvasHeight)
+        {
+            (_canvas.Width, _canvas.Height) = (canvasWidth, canvasHeight);
+            _cropTool.Redraw(_cropTool.TopLeftX, _cropTool.TopLeftY, _cropTool.Width, _cropTool.Height);
+        }
+        public void Redraw(double canvasWidth, double canvasHeight, double adornerScaleMultiplierX, double adornerScaleMultiplierY)
+        {
+            (_canvas.Width, _canvas.Height) = (canvasWidth, canvasHeight);
+            _cropTool.Redraw(_cropTool.TopLeftX * adornerScaleMultiplierX, _cropTool.TopLeftY * adornerScaleMultiplierY, _cropTool.Width * adornerScaleMultiplierX, _cropTool.Height * adornerScaleMultiplierY);
+        }
+        public void Redraw(double x, double y, double width, double height, double canvasWidth, double canvasHeight, double adornerScaleMultiplierX, double adornerScaleMultiplierY)
+        {
+            (_canvas.Width, _canvas.Height) = (canvasWidth, canvasHeight);
+            _cropTool.Redraw(x * adornerScaleMultiplierX, y * adornerScaleMultiplierY, width * adornerScaleMultiplierX, height * adornerScaleMultiplierY);
+        }
+        public void Redraw(double x, double y, double width, double height, double canvasWidth, double canvasHeight)
+        {
+            (_canvas.Width, _canvas.Height) = (canvasWidth, canvasHeight);
+            _cropTool.Redraw(x, y, width, height);
         }
     }
 }

--- a/UI-Cropping-Image-Library/CroppingImageLibrary/Services/Tools/ShadeTool.cs
+++ b/UI-Cropping-Image-Library/CroppingImageLibrary/Services/Tools/ShadeTool.cs
@@ -8,13 +8,16 @@ namespace CroppingImageLibrary.Services.Tools
     internal class ShadeTool
     {
         private readonly CropTool _cropTool;
+        private readonly Canvas _canvas;
         private readonly RectangleGeometry _rectangleGeo;
+        private readonly RectangleGeometry _grayArea;
 
         public Path ShadeOverlay { get; set; }
 
         public ShadeTool(Canvas canvas, CropTool cropTool)
         {
             _cropTool = cropTool;
+            _canvas = canvas;
 
             ShadeOverlay = new Path
             {
@@ -23,8 +26,7 @@ namespace CroppingImageLibrary.Services.Tools
             };
 
             var geometryGroup = new GeometryGroup();
-            RectangleGeometry geometry1 =
-                new RectangleGeometry(new Rect(new Size(canvas.Width, canvas.Height)));
+            _grayArea = new RectangleGeometry(new Rect(new Size(canvas.Width, canvas.Height)));
             _rectangleGeo = new RectangleGeometry(
                 new Rect(
                     _cropTool.TopLeftX,
@@ -33,13 +35,14 @@ namespace CroppingImageLibrary.Services.Tools
                     _cropTool.Height
                 )
             );
-            geometryGroup.Children.Add(geometry1);
+            geometryGroup.Children.Add(_grayArea);
             geometryGroup.Children.Add(_rectangleGeo);
             ShadeOverlay.Data = geometryGroup;
         }
 
         public void Redraw()
         {
+            _grayArea.Rect = new Rect(new Size(_canvas.Width, _canvas.Height));
             _rectangleGeo.Rect = new Rect(
                 _cropTool.TopLeftX,
                 _cropTool.TopLeftY,


### PR DESCRIPTION
## Current behaviour

- CropService does not change size when adornedElement changes, it stays in same size and place
- It's not possible to disable cropping

## Changes

- Redraw method in ShadeTool sets shading size to match with canvas
- Added Redraw method in CropService to be able to redraw it with new size and position
- Added SetEnabled method in CropService to be able to enabled and disable
- ### CropToolControl changes
     - Image Stretch have changed to uniform
     - Added SizeChanged event for SourceImage to redraw CropService